### PR TITLE
Fix for use in Doc Type Grid Editor

### DIFF
--- a/src/RJP.MultiUrlPicker/App_Plugins/RJP.MultiUrlPicker/MultiUrlPicker.js
+++ b/src/RJP.MultiUrlPicker/App_Plugins/RJP.MultiUrlPicker/MultiUrlPicker.js
@@ -113,7 +113,7 @@ angular.module("umbraco").controller("RJP.MultiUrlPickerController", function($s
     }
 
     $scope.model.value = $scope.renderModel
-    dialogService.closeAll()
+    dialogService.close()
   }
 
   function Link(link) {


### PR DESCRIPTION
This closes just the Url Picker dialog. Needed for packages like Doc
Type Grid Editor or for use as Macro Parameters.