### PR TITLE
Fix backoffice error when getByIds is called with no ids

### DIFF
--- a/src/RJP.MultiUrlPicker/App_Plugins/RJP.MultiUrlPicker/MultiUrlPicker.js
+++ b/src/RJP.MultiUrlPicker/App_Plugins/RJP.MultiUrlPicker/MultiUrlPicker.js
@@ -29,10 +29,14 @@
       }
     };
 
-    entityResource.getByIds( documentIds, 'Document' ).then( setIcon );
-    entityResource.getByIds( mediaIds, 'Media' ).then( setIcon );
+      if( documentIds.length ) {
+          entityResource.getByIds( documentIds, 'Document' ).then( setIcon );
+      }
+      if( mediaIds.length ) {
+          entityResource.getByIds( mediaIds, 'Media' ).then( setIcon );
+      }
 
-    if ( $scope.model.config ) {
+      if ( $scope.model.config ) {
       $scope.cfg = angular.extend( $scope.cfg, $scope.model.config );
     }
 

--- a/src/RJP.MultiUrlPicker/App_Plugins/RJP.MultiUrlPicker/MultiUrlPicker.js
+++ b/src/RJP.MultiUrlPicker/App_Plugins/RJP.MultiUrlPicker/MultiUrlPicker.js
@@ -29,14 +29,14 @@
       }
     };
 
-      if( documentIds.length ) {
-          entityResource.getByIds( documentIds, 'Document' ).then( setIcon );
-      }
-      if( mediaIds.length ) {
-          entityResource.getByIds( mediaIds, 'Media' ).then( setIcon );
-      }
+    if( documentIds.length ) {
+        entityResource.getByIds( documentIds, 'Document' ).then( setIcon );
+    }
+    if( mediaIds.length ) {
+        entityResource.getByIds( mediaIds, 'Media' ).then( setIcon );
+    }
 
-      if ( $scope.model.config ) {
+    if ( $scope.model.config ) {
       $scope.cfg = angular.extend( $scope.cfg, $scope.model.config );
     }
 


### PR DESCRIPTION
This might only be 7.3 and onwards, but it throws a bunch of red errormessages to the backoffice, which is unwanted.

Since the call wouldn't have any effect when the arrays are empty, omitting them entirely should make no difference.
