### PR TITLE
Prevent extra calls to server

### DIFF
--- a/src/RJP.MultiUrlPicker/App_Plugins/RJP.MultiUrlPicker/MultiUrlPicker.js
+++ b/src/RJP.MultiUrlPicker/App_Plugins/RJP.MultiUrlPicker/MultiUrlPicker.js
@@ -29,9 +29,13 @@
       }
     };
 
-    entityResource.getByIds( documentIds, 'Document' ).then( setIcon );
-    entityResource.getByIds( mediaIds, 'Media' ).then( setIcon );
-
+    if (documentIds.length > 0) {
+        entityResource.getByIds(documentIds, 'Document').then(setIcon);
+    }
+    if (mediaIds.length > 0) {
+        entityResource.getByIds(mediaIds, 'Media').then(setIcon);
+    }
+    
     if ( $scope.model.config ) {
       $scope.cfg = angular.extend( $scope.cfg, $scope.model.config );
     }


### PR DESCRIPTION
Hi,

We had some issues with the picker. For some reason we got a lot of 404 errors. It turned out the server gets a lot of entity requests with no id in there. 

So I took a look at the js en changed it a little.
If the id collection has no id's there will be a request to the server. First check if there are any id's, then make a request to the server.
