### PR TITLE
#42: Log original request with 'deleted node' warning

### DIFF
--- a/src/RJP.MultiUrlPicker/Models/MultiUrls.cs
+++ b/src/RJP.MultiUrlPicker/Models/MultiUrls.cs
@@ -19,37 +19,37 @@
         {
         }
 
-        internal MultiUrls(JArray propertyData)
+        internal MultiUrls(JArray propertyData, string requestingUrl)
         {
             _propertyData = propertyData.ToString();
 
-            Initialize(propertyData);
+            Initialize(propertyData, requestingUrl);
         }
 
-        public MultiUrls(string propertyData)
+        public MultiUrls(string propertyData, string requestingUrl)
         {
             _propertyData = propertyData;
 
             if (!string.IsNullOrEmpty(propertyData))
             {
                 var relatedLinks = JsonConvert.DeserializeObject<JArray>(propertyData);
-                Initialize(relatedLinks);
+                Initialize(relatedLinks, requestingUrl);
             }
         }
 
-        private void Initialize(JArray data)
+        private void Initialize(JArray data, string requestingUrl)
         {
             foreach (var item in data)
             {
                 var newLink = new Link(item);
                 if (!newLink.Deleted)
                 {
-                    _multiUrls.Add(new Link(item));
+                    _multiUrls.Add(newLink);
                 }
                 else
                 {
                     LogHelper.Warn<MultiUrls>(
-                        string.Format("MultiUrlPicker value converter skipped a link as the node has been upublished/deleted (Id: {0}), ", newLink.Id));
+                        string.Format("MultiUrlPicker value converter skipped a link as the node has been unpublished/deleted (Udi: {0}, Request: {1})", newLink.Udi, requestingUrl));
                 }
             }
         }

--- a/src/RJP.MultiUrlPicker/MultiUrlPickerValueConverter.cs
+++ b/src/RJP.MultiUrlPicker/MultiUrlPickerValueConverter.cs
@@ -14,6 +14,7 @@ namespace RJP.MultiUrlPicker
     using Umbraco.Core.Models.PublishedContent;
     using Umbraco.Core.PropertyEditors;
     using Umbraco.Core.Services;
+    using Umbraco.Web;
 
     using Models;
 
@@ -64,7 +65,7 @@ namespace RJP.MultiUrlPicker
                 return isMultiple ? new MultiUrls() : null;
             }
 
-            var urls = new MultiUrls((JArray)source);
+            var urls = new MultiUrls((JArray)source, UmbracoContext.Current.PublishedContentRequest.Uri.ToString());
             if(isMultiple)
             {
                 if(maxNumberOfItems > 0)


### PR DESCRIPTION
"Fix" for #42. Unfortunately there isn't any more info available about which property is causing the warning.

I have a similar fix for 1.3.2, but would need a branch to PR it to.