### PR TITLE
Using RJP in Grid editor wasn't working

### DIFF
--- a/src/RJP.MultiUrlPicker.Web.UI/MultiUrlPicker.js
+++ b/src/RJP.MultiUrlPicker.Web.UI/MultiUrlPicker.js
@@ -13,10 +13,12 @@
       $scope.model.value = []
     }
 
-    $scope.model.value.forEach(function (link) {
-      link.icon = iconHelper.convertFromLegacyIcon(link.icon)
-      this.renderModel.push(link)
-    }.bind(this))
+    if ($scope.model.value) {
+        $scope.model.value.forEach(function (link) {
+            link.icon = iconHelper.convertFromLegacyIcon(link.icon)
+            this.renderModel.push(link)
+        }.bind(this))
+    }
 
     $scope.$on('formSubmitting', function () {
       $scope.model.value = this.renderModel


### PR DESCRIPTION
$scope.model.value can be null when used in Grid editor, this caused a for loop to fail. Simply added a check to see if the value is null. If yes, skip the for loop. I tested this on my local install and it didn't seem to break anything else.