### PR TITLE
Fixes #45: Adds querystring support

### DIFF
--- a/src/RJP.MultiUrlPicker.Web.UI/MultiUrlPicker.html
+++ b/src/RJP.MultiUrlPicker.Web.UI/MultiUrlPicker.html
@@ -5,7 +5,7 @@
                 <umb-node-preview icon="link.icon"
                                   name="link.name"
                                   published="link.published"
-                                  description="link.url + link.querystring"
+                                  description="link.url + (link.querystring ? link.querystring : '')"
                                   sortable="!ctrl.sortableOptions.disabled"
                                   allow-remove="true"
                                   allow-open="true"

--- a/src/RJP.MultiUrlPicker.Web.UI/MultiUrlPicker.html
+++ b/src/RJP.MultiUrlPicker.Web.UI/MultiUrlPicker.html
@@ -5,7 +5,7 @@
                 <umb-node-preview icon="link.icon"
                                   name="link.name"
                                   published="link.published"
-                                  description="link.url"
+                                  description="link.url + link.querystring"
                                   sortable="!ctrl.sortableOptions.disabled"
                                   allow-remove="true"
                                   allow-open="true"

--- a/src/RJP.MultiUrlPicker/Models/Link.cs
+++ b/src/RJP.MultiUrlPicker/Models/Link.cs
@@ -109,6 +109,12 @@
                 if (string.IsNullOrEmpty(_url))
                 {
                     _url = PublishedContent?.Url ?? _linkItem.Value<string>("url");
+
+                    var qs = _linkItem.Value<string>("querystring");
+                    if (!string.IsNullOrWhiteSpace(qs))
+                    {
+                        _url += qs;
+                    }
                 }
                 return _url;
             }

--- a/src/RJP.MultiUrlPicker/Models/LinkDisplay.cs
+++ b/src/RJP.MultiUrlPicker/Models/LinkDisplay.cs
@@ -30,5 +30,8 @@
 
         [DataMember(Name = "url")]
         public string Url { get; set; }
+
+        [DataMember(Name = "querystring")]
+        public string Querystring { get; set; }
     }
 }

--- a/src/RJP.MultiUrlPicker/Models/LinkDto.cs
+++ b/src/RJP.MultiUrlPicker/Models/LinkDto.cs
@@ -28,6 +28,9 @@
         [DataMember(Name = "url")]
         public string Url { get; set; }
 
+        [DataMember(Name = "querystring")]
+        public string Querystring { get; set; }
+
         internal bool Published { get; set; }
     }
 }

--- a/src/RJP.MultiUrlPicker/MultiUrlPickerPropertyEditor.cs
+++ b/src/RJP.MultiUrlPicker/MultiUrlPickerPropertyEditor.cs
@@ -216,6 +216,7 @@
                                 Published = published,
                                 Udi = udi,
                                 Url = url,
+                                Querystring = dto.Querystring
                             });
                         }
                         else
@@ -226,7 +227,8 @@
                                 Name = dto.Name,
                                 Published = true,
                                 Target = dto.Target,
-                                Url = dto.Url
+                                Url = dto.Url,
+                                Querystring = dto.Querystring
                             });
                         }
                     }
@@ -258,7 +260,8 @@
                             Name = link.Name,
                             Target = link.Target,
                             Udi = link.Udi,
-                            Url = link.Udi == null ? link.Url : null // only save the url for external links
+                            Url = link.Udi == null ? link.Url : null, // only save the url for external links
+                            Querystring = link.Querystring
                         },
                         new JsonSerializerSettings
                         {


### PR DESCRIPTION
This injects an additional "Query String" field into the default Umbraco link picker dialog and then updates the core package code to use it. This does not modify any files on disk so should be safe for upgrades (unless core changes the view URL or adds a querystring themselves). This is currently un-localized, but I'm sure someone can add that ability if needed.

Hope this helps.