### PR TITLE
 Added hide query string and target checkboxes 

### DIFF
--- a/src/RJP.MultiUrlPicker.Web.UI/MultiUrlPicker.js
+++ b/src/RJP.MultiUrlPicker.Web.UI/MultiUrlPicker.js
@@ -68,6 +68,13 @@
         hideQuerystring: $scope.model.config.hideQuerystring === '1',
         hideTarget: $scope.model.config.hideTarget === '1',
         submit: function (model) {
+          // Parse query string: add missing ? or truncate to null
+          var querystring = model.target.querystring || null;
+          if (querystring) {
+            if (querystring[0] !== '?') querystring = '?' + querystring;
+            if (querystring.length === 1) querystring = null;
+          }
+
           if (model.target.url) {
             if (link) {
               if (link.isMedia && link.url === model.target.url) {
@@ -82,7 +89,7 @@
               link.name = model.target.name || model.target.url
               link.target = model.target.target
               link.url = model.target.url
-              link.querystring = model.target.querystring
+              link.querystring = querystring
             } else {
               link = {
                 id: model.target.id,
@@ -91,7 +98,7 @@
                 target: model.target.target,
                 udi: model.target.udi,
                 url: model.target.url,
-                querystring: model.target.querystring
+                querystring: querystring
               }
               this.renderModel.push(link)
             }

--- a/src/RJP.MultiUrlPicker.Web.UI/MultiUrlPicker.js
+++ b/src/RJP.MultiUrlPicker.Web.UI/MultiUrlPicker.js
@@ -65,7 +65,8 @@
         view: 'linkpicker',
         currentTarget: target,
         show: true,
-        querystring: true,
+        hideQuerystring: $scope.model.config.hideQuerystring === '1',
+        hideTarget: $scope.model.config.hideTarget === '1',
         submit: function (model) {
           if (model.target.url) {
             if (link) {
@@ -126,7 +127,7 @@
             // Inject the querystring field
             var $markup = $(response.data)
             var $urlField = $markup.find('[label="@defaultdialogs_urlLinkPicker"]')
-            $urlField.after('<umb-control-group label="Query String" ng-if="model.querystring"><input type="text" placeholder="Query String" class="umb-editor umb-textstring" ng-model="model.target.querystring"/></umb-control-group>')
+            $urlField.after('<umb-control-group label="Query string" ng-if="!model.hideQuerystring"><input type="text" placeholder="Query string" class="umb-editor umb-textstring" ng-model="model.target.querystring" /></umb-control-group>');
             response.data = $markup[0]
           }
           return response

--- a/src/RJP.MultiUrlPicker/MultiUrlPickerPropertyEditor.cs
+++ b/src/RJP.MultiUrlPicker/MultiUrlPickerPropertyEditor.cs
@@ -36,6 +36,8 @@ namespace RJP.MultiUrlPicker
             {
                 {"minNumberOfItems", null},
                 {"maxNumberOfItems", null},
+                {"hideQuerystring", "0"},
+                {"hideTarget", "0"},
                 {"version", Information.Version.ToString(3)},
             };
         }
@@ -63,6 +65,12 @@ namespace RJP.MultiUrlPicker
 
             [PreValueField("maxNumberOfItems", "Max number of items", "number")]
             public int? MaxNumberOfItems { get; set; }
+
+            [PreValueField("hideQuerystring", "Hide query string input.", "boolean")]
+            public string HideQuerystring { get; set; }
+
+            [PreValueField("hideTarget", "Hide target/open in new window or tab checkbox.", "boolean")]
+            public string HideTarget { get; set; }
 
             [PreValueField("version", "Multi Url Picker version", "hidden", HideLabel = true)]
             public string Version { get; set; }


### PR DESCRIPTION
This is the PR for issue #75 that adds checkboxes for hiding the query string and target (open in new window or tab) fields in the link picker.