### PR TITLE
Moved `ng-repeat` to the `umb-node-preview` directive

### DIFF
--- a/src/RJP.MultiUrlPicker.Web.UI/MultiUrlPicker.html
+++ b/src/RJP.MultiUrlPicker.Web.UI/MultiUrlPicker.html
@@ -1,18 +1,17 @@
 ﻿<div ng-controller="RJP.MultiUrlPickerController as ctrl" class="umb-editor umb-contentpicker">
     <ng-form name="multiUrlPickerForm">
         <div ui-sortable="ctrl.sortableOptions" ng-model="ctrl.renderModel">
-            <div ng-repeat="link in ctrl.renderModel">
-                <umb-node-preview icon="link.icon"
-                                  name="link.name"
-                                  published="link.published"
-                                  description="link.url + (link.querystring ? link.querystring : '')"
-                                  sortable="!ctrl.sortableOptions.disabled"
-                                  allow-remove="true"
-                                  allow-open="true"
-                                  on-remove="ctrl.remove($index)"
-                                  on-open="ctrl.openLinkPicker(link, $index)">
-                </umb-node-preview>
-            </div>
+            <umb-node-preview ng-repeat="link in ctrl.renderModel"
+                              icon="link.icon"
+                              name="link.name"
+                              published="link.published"
+                              description="link.url + (link.querystring ? link.querystring : '')"
+                              sortable="!ctrl.sortableOptions.disabled"
+                              allow-remove="true"
+                              allow-open="true"
+                              on-remove="ctrl.remove($index)"
+                              on-open="ctrl.openLinkPicker(link, $index)">
+            </umb-node-preview>
         </div>
 
         <a ng-show="!model.config.maxNumberOfItems || ctrl.renderModel.length < model.config.maxNumberOfItems"


### PR DESCRIPTION
Instead of calling `umb-node-preview` directive for each link,
we can pass all the links to it.  This will then add the link separators.

The `sortableOptions` are still handled from the parent container.

---

Here's a before and after...

### Before

![rjp-before](https://user-images.githubusercontent.com/209066/44327632-15d21680-a457-11e8-8fb5-722904afd90c.png)

### After

![rjp-after](https://user-images.githubusercontent.com/209066/44327637-18cd0700-a457-11e8-9ad9-156c1df1e1ba.png)
